### PR TITLE
Extend quadratic_model with broken linear model.

### DIFF
--- a/slr/slr/models.py
+++ b/slr/slr/models.py
@@ -4,72 +4,88 @@ import statsmodels.api as sm
 # define the statistical model
 def linear_acceleration_model(df):
     """define a simple linear model, with nodal tide and without wind (no acceleration)"""
-    y = df['height']
+    y = df["height"]
     X = np.c_[
-        df['year']-1970,
-        (df['year'] - 1970) * (df['year'] - 1970),
-        np.cos(2*np.pi*(df['year']-1970)/18.613),
-        np.sin(2*np.pi*(df['year']-1970)/18.613)
+        df["year"] - 1970,
+        (df["year"] - 1970) * (df["year"] - 1970),
+        np.cos(2 * np.pi * (df["year"] - 1970) / 18.613),
+        np.sin(2 * np.pi * (df["year"] - 1970) / 18.613),
     ]
-    month = np.mod(df['year'], 1) * 12.0
-    names = ['Constant', 'Trend', 'Acceleration', 'Nodal U', 'Nodal V']
+    month = np.mod(df["year"], 1) * 12.0
+    names = ["Constant", "Trend", "Acceleration", "Nodal U", "Nodal V"]
     X = sm.add_constant(X)
-    model = sm.OLS(y, X, missing='drop')
+    model = sm.OLS(y, X, missing="drop")
     fit = model.fit()
     return fit, names
 
 
 # define the statistical model
-def quadratic_model(df, with_wind=True, with_ar=True, start_acc=1890):
+def quadratic_model(df, with_wind=True, with_ar=True, with_nodal=True, start_acc=None):
     """This model computes a parabolic linear fit. This corresponds to the hypothesis that sea-level is accelerating."""
-    y = df['height']
-    X = np.c_[
-        df['year'],
-        (df['year']>=start_acc)*(df['year']-start_acc) * (df['year']-start_acc),
-        np.cos(2*np.pi*(df['year'])/18.613),
-        np.sin(2*np.pi*(df['year'])/18.613)
+
+    y = df["height"]
+
+    epoch = 1970
+    if start_acc:
+        epoch = start_acc
+
+    # linear term, 0 in 1970, 30 in 2000
+    linear_term = df["year"] - epoch
+
+    # use quadratic term since epoch for comparison with other models.
+    # 1 in 1969, 0 in 1970, 1 in 1971, 4 in 1972, masked if before start_acc
+    quadratic_term = (df["year"] - epoch) * (df["year"] - epoch)
+    if start_acc is not None:
+        quadratic_term = (df["year"] >= start_acc) * (df["year"] - epoch) ** 2
+
+    # regression terms
+    X = np.c_[linear_term, quadratic_term]
+    names = [
+        "Constant (in year {epoch})",
+        "Trend",
+        f"Acceleration from {start_acc}",
     ]
-    names = ['Constant', 'Trend', f'Acceleration from {start_acc}', 'Nodal U', 'Nodal V']
+
+    if with_nodal:
+        nodal_cos_term = np.cos(2 * np.pi * (df["year"] - epoch) / 18.613)
+        nodal_sin_term = np.sin(2 * np.pi * (df["year"] - epoch) / 18.613)
+        X = np.c_[X, nodal_cos_term, nodal_sin_term]
+        names.extend(["Nodal U", "Nodal V"])
+
     if with_wind:
-        X = np.c_[
-            X,
-            df['u2'],
-            df['v2']
-        ]
-        names.extend(['Wind $u^2$', 'Wind $v^2$'])
+        X = np.c_[X, df["u2"], df["v2"]]
+        names.extend(["Wind $u^2$", "Wind $v^2$"])
+
+    # add constant to the start
     X = sm.add_constant(X)
-    
+
     if with_ar:
-        model = sm.GLSAR(y, X, missing='drop', rho=1)
-        fit = model.iterative_fit(cov_type='HC0')
+        model = sm.GLSAR(y, X, missing="drop", rho=1)
+        fit = model.iterative_fit(cov_type="HC0")
     else:
-        model = sm.OLS(y, X, missing='drop')
-        fit = model.fit(cov_type='HC0')
-    
+        model = sm.OLS(y, X, missing="drop")
+        fit = model.fit(cov_type="HC0")
+
     return fit, names
 
 
 # define the statistical model
 def broken_linear_model(df, with_wind=True):
     """This model fits the sea-level rise has started to rise faster in 1993."""
-    y = df['height']
+    y = df["height"]
     X = np.c_[
-        df['year']-1970,
-        (df['year'] > 1993) * (df['year'] - 1993),
-        np.cos(2*np.pi*(df['year']-1970)/18.613),
-        np.sin(2*np.pi*(df['year']-1970)/18.613)
+        df["year"] - 1970,
+        (df["year"] > 1993) * (df["year"] - 1993),
+        np.cos(2 * np.pi * (df["year"] - 1970) / 18.613),
+        np.sin(2 * np.pi * (df["year"] - 1970) / 18.613),
     ]
-    names = ['Constant', 'Trend', '+trend (1993)', 'Nodal U', 'Nodal V']
+    names = ["Constant", "Trend", "+trend (1993)", "Nodal U", "Nodal V"]
     if with_wind:
-        X = np.c_[
-            X,
-            df['u2'],
-            df['v2']
-        ]
-        names.extend(['Wind $u^2$', 'Wind $v^2$'])
+        X = np.c_[X, df["u2"], df["v2"]]
+        names.extend(["Wind $u^2$", "Wind $v^2$"])
     X = sm.add_constant(X)
     model_broken_linear = sm.GLSAR(y, X, rho=1)
-    fit = model_broken_linear.iterative_fit(cov_type='HC0')
+    fit = model_broken_linear.iterative_fit(cov_type="HC0")
     return fit, names
 
 
@@ -78,25 +94,21 @@ def linear_model(df, with_wind=True, with_ar=True):
     See the latest report for a detailed description.
     """
 
-    y = df['height']
+    y = df["height"]
     X = np.c_[
-        df['year']-1970,
-        np.cos(2*np.pi*(df['year']-1970)/18.613),
-        np.sin(2*np.pi*(df['year']-1970)/18.613)
+        df["year"] - 1970,
+        np.cos(2 * np.pi * (df["year"] - 1970) / 18.613),
+        np.sin(2 * np.pi * (df["year"] - 1970) / 18.613),
     ]
-    month = np.mod(df['year'], 1) * 12.0
-    names = ['Constant', 'Trend', 'Nodal U', 'Nodal V']
+    month = np.mod(df["year"], 1) * 12.0
+    names = ["Constant", "Trend", "Nodal U", "Nodal V"]
     if with_wind:
-        X = np.c_[
-            X,
-            df['u2'],
-            df['v2']
-        ]
-        names.extend(['Wind $u^2$', 'Wind $v^2$'])
+        X = np.c_[X, df["u2"], df["v2"]]
+        names.extend(["Wind $u^2$", "Wind $v^2$"])
     X = sm.add_constant(X)
     if with_ar:
-        model = sm.GLSAR(y, X, missing='drop', rho=1)
+        model = sm.GLSAR(y, X, missing="drop", rho=1)
     else:
-        model = sm.OLS(y, X, missing='drop')
-    fit = model.fit(cov_type='HC0')
+        model = sm.OLS(y, X, missing="drop")
+    fit = model.fit(cov_type="HC0")
     return fit, names

--- a/slr/tests/test_models.py
+++ b/slr/tests/test_models.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+
+import pandas as pd
+import numpy as np
+
+import pytest
+
+import slr.models
+
+
+@pytest.fixture
+def df_linear():
+    """create a dataframe where sea level is 0.1 * year since 1900"""
+    rows = []
+    for year in range(1900, 2020):
+        row = {"year": year, "height": (year - 1970) * 0.1}
+        rows.append(row)
+    df = pd.DataFrame(rows)
+    return df
+
+
+@pytest.fixture
+def df_quadratic():
+    """create a dataframe where sea level is 0.1 * year since 1900"""
+    rows = []
+    epoch = 1970
+    for year in range(1900, 2020):
+        height = 0.1 * (year - 1970) * 0.1 + 0.2 * (year - epoch) ** 2
+        row = {"year": year, "height": height}
+        rows.append(row)
+    df = pd.DataFrame(rows)
+    return df
+
+
+@pytest.fixture
+def df_nodal():
+    """create a dataframe where sea level is 0.1 * year since 1900"""
+    rows = []
+    epoch = 1970
+    for year in range(1900, 2020):
+        height = 0.1 * (year - epoch) * 0.1 + 0.2 * (year - epoch) ** 2
+        height += 0.3 * np.sin(2 * np.pi * (year - epoch) / 18.613)
+        row = {"year": year, "height": height}
+        rows.append(row)
+    df = pd.DataFrame(rows)
+    return df
+
+
+@pytest.fixture
+def df_acceleration_1960():
+    """create a dataframe where sea level is 0.1 * year since 1900"""
+    rows = []
+    epoch = 1970
+    for year in range(1900, 2020):
+        height = 0.1 * (year - epoch)
+        if year >= 1960:
+            height += 0.5 * (year - 1960) * (year - 1960)
+        row = {"year": year, "height": height}
+        rows.append(row)
+    df = pd.DataFrame(rows)
+    return df
+
+
+def test_quadratic_model_linear_data(df_linear):
+    """test whether we get correct results with linear input"""
+    fit, names = slr.models.quadratic_model(df_linear, with_wind=False, with_ar=False)
+
+    np.testing.assert_almost_equal(fit.params["const"], 0, decimal=5)
+    np.testing.assert_almost_equal(fit.params["x1"], 0.1, decimal=0.5)
+
+
+def test_quadratic_model_quadratic_data(df_quadratic):
+    """test whether we get correct results with quadratic input"""
+    fit, names = slr.models.quadratic_model(
+        df_quadratic, with_wind=False, with_ar=False
+    )
+
+    np.testing.assert_almost_equal(fit.params["const"], 0, decimal=5)
+    np.testing.assert_almost_equal(fit.params["x1"], 0.1, decimal=0.5)
+    np.testing.assert_almost_equal(fit.params["x2"], 0.2, decimal=0.5)
+    np.testing.assert_almost_equal(fit.params["x3"], 0, decimal=0.5)
+
+
+def test_quadratic_model_nodal_data(df_nodal):
+    """test whether we get correct results with quadratic input"""
+    fit, names = slr.models.quadratic_model(df_nodal, with_wind=False, with_ar=False)
+    print(fit.params)
+
+    np.testing.assert_almost_equal(fit.params["const"], 0, decimal=5)
+    np.testing.assert_almost_equal(fit.params["x1"], 0.1, decimal=0.5)
+    np.testing.assert_almost_equal(fit.params["x2"], 0.2, decimal=0.5)
+    np.testing.assert_almost_equal(fit.params["x4"], 0.3, decimal=0.5)
+
+
+def test_quadratic_model_acceleration_1960_data(df_acceleration_1960):
+    """test whether we get correct results with quadratic input"""
+    fit, names = slr.models.quadratic_model(
+        df_acceleration_1960,
+        with_wind=False,
+        with_ar=False,
+        start_acc=1960,
+    )
+
+    # constant now refers to 1960
+    np.testing.assert_almost_equal(fit.params["const"], -1, decimal=5)
+    np.testing.assert_almost_equal(fit.params["x1"], 0.1, decimal=0.5)
+    np.testing.assert_almost_equal(fit.params["x2"], 0.5, decimal=0.5)


### PR DESCRIPTION
Makes the *quadratic_model* in `/slr` more general. 
The acceleration term can start at a date of choice instead of on the first year of the time series.
Also, the autoregressive process is made an option.
Default option is still to start from 1890 so the notebook *dutch-sea-level-monitor.ipynb* can run without any modifications and provides the same results.